### PR TITLE
fix: add config-example.json to goreleaser docker extra_files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ dockers:
       - "docker.io/astromechza/ecowitt-data-prometheus-relay:{{ .Tag }}-amd64"
     dockerfile: Dockerfile
     use: buildx
+    extra_files:
+      - config-example.json
     build_flag_templates:
       - "--platform=linux/amd64"
   - id: arm64
@@ -36,6 +38,8 @@ dockers:
       - "docker.io/astromechza/ecowitt-data-prometheus-relay:{{ .Tag }}-arm64"
     dockerfile: Dockerfile
     use: buildx
+    extra_files:
+      - config-example.json
     build_flag_templates:
       - "--platform=linux/arm64"
 


### PR DESCRIPTION
## Summary

- Release build failed because `Dockerfile` does `COPY config-example.json /config.json` but goreleaser's docker build context only includes the compiled binary by default
- Added `extra_files: [config-example.json]` to both `amd64` and `arm64` docker entries in `.goreleaser.yml`

## Root cause

Error from failed run:
```
#6 [3/3] COPY config-example.json /config.json
#6 ERROR: failed to calculate checksum of ref ...: "/config-example.json": not found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
